### PR TITLE
Two small bugfixes to argument/parameter parsing

### DIFF
--- a/src/fe.c
+++ b/src/fe.c
@@ -657,7 +657,12 @@ static fe_Object* eval(fe_Context *ctx, fe_Object *obj, fe_Object *env, fe_Objec
 
         case P_FN: case P_MAC:
           va = fe_cons(ctx, env, arg);
-          fe_nextarg(ctx, &arg);
+          if (!isnil(vb = fe_nextarg(ctx, &arg))) {
+            checktype(ctx, vb, FE_TPAIR);
+            while (!isnil(vb)) {
+              checktype(ctx, fe_nextarg(ctx, &vb), FE_TSYMBOL);
+            }
+          }
           res = object(ctx);
           settype(res, prim(fn) == P_FN ? FE_TFUNC : FE_TMACRO);
           cdr(res) = va;


### PR DESCRIPTION
I also have various patches to add miscellaneous features, like:
- GT, GTE (very trivial)
- variadic comparison operators and "is"
- read (fe_string -> AST)
- eval (again, very trivial)
- load (for files)
- a rather big patch to make the bindings in recursive functions lexical instead of dynamic, using the Y combinator (no gensym) - implemented as either a new Scheme-style syntax, or alternatively, changing how P_SET behaves when the second argument is a regular function declaration.

Let me know if you would accept or like to see any of those so I can make a PR.