### PR TITLE
docs: fix simple typo, intialized -> initialized

### DIFF
--- a/doc/capi.md
+++ b/doc/capi.md
@@ -1,6 +1,6 @@
 
 # C API
-To use `fe` in a project a `fe_Context` must first be intialized;
+To use `fe` in a project a `fe_Context` must first be initialized;
 this is done by using the `fe_open()` function. The function expects a
 block of memory (typically greater than 16kb), the block is used by the
 context to store objects and context state and should remain valid for


### PR DESCRIPTION
There is a small typo in doc/capi.md.

Should read `initialized` rather than `intialized`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md