### PR TITLE
build.sh: replace bash with sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/bin/sh
 gcc src/fe.c -DFE_STANDALONE -O3 -o fe -Wall -Wextra -std=c89 -pedantic


### PR DESCRIPTION
For increased portability.