### PR TITLE
Tiny improvement for `read_()`

### DIFF
--- a/src/fe.c
+++ b/src/fe.c
@@ -513,7 +513,7 @@ static fe_Object* read_(fe_Context *ctx, fe_ReadFn fn, void *udata) {
         if (chr == '\0') { fe_error(ctx, "unclosed string"); }
         if (chr == '\\') {
           chr = fn(ctx, udata);
-          if (strchr("\\nrt", chr)) { chr = strchr("\\\\n\nr\rt\t", chr)[1]; }
+          if (strchr("nrt", chr)) { chr = strchr("n\nr\rt\t", chr)[1]; }
         }
         v = buildstring(ctx, v, chr);
         chr = fn(ctx, udata);

--- a/src/fe.c
+++ b/src/fe.c
@@ -474,7 +474,7 @@ static fe_Object* read_(fe_Context *ctx, fe_ReadFn fn, void *udata) {
       return NULL;
 
     case ';':
-      while (chr && chr != '\n') { chr = fn(ctx, udata); }
+      while (chr && chr != '\n' && chr != '\r') { chr = fn(ctx, udata); }
       return read_(ctx, fn, udata);
 
     case ')':
@@ -513,7 +513,7 @@ static fe_Object* read_(fe_Context *ctx, fe_ReadFn fn, void *udata) {
         if (chr == '\0') { fe_error(ctx, "unclosed string"); }
         if (chr == '\\') {
           chr = fn(ctx, udata);
-          if (strchr("nrt", chr)) { chr = strchr("n\nr\rt\t", chr)[1]; }
+          if (strchr("\\nrt", chr)) { chr = strchr("\\\\n\nr\rt\t", chr)[1]; }
         }
         v = buildstring(ctx, v, chr);
         chr = fn(ctx, udata);

--- a/src/fe.c
+++ b/src/fe.c
@@ -809,11 +809,11 @@ fe_Context* fe_open(void *ptr, int size) {
   }
 
   /* init objects */
+  save = fe_savegc(ctx);
   ctx->t = fe_symbol(ctx, "t");
   fe_set(ctx, ctx->t, ctx->t);
 
   /* register built in primitives */
-  save = fe_savegc(ctx);
   for (i = 0; i < P_MAX; i++) {
     fe_Object *v = object(ctx);
     settype(v, FE_TPRIM);

--- a/src/fe.c
+++ b/src/fe.c
@@ -454,7 +454,7 @@ void fe_set(fe_Context *ctx, fe_Object *sym, fe_Object *v) {
 static fe_Object rparen;
 
 static fe_Object* read_(fe_Context *ctx, fe_ReadFn fn, void *udata) {
-  const char *delimiter = " \n\t\r();";
+  const char *delimiter = " \n\t\r\"'();";
   fe_Object *v, *res, **tail;
   fe_Number n;
   int chr, gc;


### PR DESCRIPTION
Before this change, if the line break was `\r`, comments didn't work correctly.